### PR TITLE
Should be "b.bundle" not "w.bundle"

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -116,7 +116,7 @@ Calling `b.bundle()` extra times past the first time will be much faster due
 to caching.
 
 **Important:** Watchify will not emit `'update'` events until you've called
-`w.bundle()` once and completely drained the stream it returns.
+`b.bundle()` once and completely drained the stream it returns.
 
 ```js
 var fs = require('fs');


### PR DESCRIPTION
I was rather confused by the "w.bundle", and I think it's a typo for b.bundle?
