### PR TITLE
call writeFileSync where callback is ignored

### DIFF
--- a/test/bin.js
+++ b/test/bin.js
@@ -27,7 +27,7 @@ test('bin', function (t) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
                 t.equal(output, '555\n');
-                fs.writeFile(files.main, 'console.log(333)');
+                fs.writeFileSync(files.main, 'console.log(333)');
             })
         }
         else if (lineNum === 2) {


### PR DESCRIPTION
As https://github.com/nodejs/node/pull/12562 landed in Node.js,
calling an asynchronous function without callback function will fail
in Node.js version 8.