### PR TITLE
Add troubleshooting information for silenced errors

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -134,7 +134,10 @@ b.on('update', bundle);
 bundle();
 
 function bundle() {
-  b.bundle().pipe(fs.createWriteStream('output.js'));
+  b.bundle()
+    .on('error', console.error)
+    .pipe(fs.createWriteStream('output.js'))
+  ;
 }
 ```
 
@@ -220,6 +223,19 @@ It may be related to a bug in `fsevents` (see [#250](https://github.com/substack
 and [stackoverflow](http://stackoverflow.com/questions/26708205/webpack-watch-isnt-compiling-changed-files/28610124#28610124)).
 Try the `--poll` flag
 and/or renaming the project's directory - that might help.
+
+## watchify swallows errors
+
+To ensure errors are reported you have to add a event listener to your bundle stream. For more information see ([browserify/browserify#1487 (comment)](https://github.com/browserify/browserify/issues/1487#issuecomment-173357516) and [stackoverflow](https://stackoverflow.com/a/22389498/1423220))
+
+**Example:**
+```
+var b = browserify();
+b.bundle()
+  .on('error', console.error)
+   ...
+;
+```
 
 # see also
 


### PR DESCRIPTION
There's been some issues and confusion (https://github.com/browserify/watchify/issues/350, https://github.com/browserify/watchify/issues/323, https://github.com/browserify/watchify/issues/266) about the change in behavior introduced by watchify when it is registered as browserify plugin. 

Some people expect node to crash on errors, and are not aware of how Nodes event handling system works. Although this isn't a issue directly related to watchify, it might be helpful to have some guidance in the docs..

I've added a extra subsection to the troubleshooting docs. And I also updated the example snippet with a error handler.

Closes #350
Closes #323