### PR TITLE
test: add callbacks

### DIFF
--- a/test/bin.js
+++ b/test/bin.js
@@ -18,7 +18,7 @@ mkdirp.sync(tmpdir);
 fs.writeFileSync(files.main, 'console.log(555)');
 
 test('bin', function (t) {
-    t.plan(4);
+    t.plan(5);
     var ps = spawn(cmd, [ files.main, '-o', files.bundle, '-v' ]);
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
@@ -27,7 +27,7 @@ test('bin', function (t) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
                 t.equal(output, '555\n');
-                fs.writeFile(files.main, 'console.log(333)');
+                fs.writeFile(files.main, 'console.log(333)', t.ifError);
             })
         }
         else if (lineNum === 2) {

--- a/test/bin_brfs.js
+++ b/test/bin_brfs.js
@@ -24,7 +24,7 @@ fs.writeFileSync(files.main, [
 fs.writeFileSync(files.lines, 'beep\nboop');
 
 test('bin brfs', function (t) {
-    t.plan(4);
+    t.plan(5);
     var ps = spawn(cmd, [
         files.main,
         '-t', require.resolve('brfs'), '-v',
@@ -37,7 +37,7 @@ test('bin brfs', function (t) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
                 t.equal(output, 'BEEP\nBOOP\n');
-                fs.writeFile(files.lines, 'robo-bOOgie');
+                fs.writeFile(files.lines, 'robo-bOOgie', t.ifError);
             })
         }
         else if (lineNum === 2) {

--- a/test/bin_pipe.js
+++ b/test/bin_pipe.js
@@ -18,7 +18,7 @@ mkdirp.sync(tmpdir);
 fs.writeFileSync(files.main, 'console.log(num * 2)');
 
 test('bin with pipe', function (t) {
-    t.plan(4);
+    t.plan(5);
     var ps = spawn(cmd, [
         files.main,
         '-o', 'uglifyjs - --enclose 11:num > ' + files.bundle,
@@ -31,7 +31,7 @@ test('bin with pipe', function (t) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
                 t.equal(output, '22\n');
-                fs.writeFile(files.main, 'console.log(num * 3)');
+                fs.writeFile(files.main, 'console.log(num * 3)', t.ifError);
             });
         }
         else if (lineNum === 2) {

--- a/test/bin_standalone.js
+++ b/test/bin_standalone.js
@@ -18,7 +18,7 @@ mkdirp.sync(tmpdir);
 fs.writeFileSync(files.main, 'console.log(555)');
 
 test('bin with standalone', function (t) {
-    t.plan(4);
+    t.plan(5);
     var ps = spawn(cmd, [ files.main, '-o', files.bundle, '-v', '-s', 'XXX' ]);
     var lineNum = 0;
     ps.stderr.pipe(split()).on('data', function (line) {
@@ -27,7 +27,7 @@ test('bin with standalone', function (t) {
             run(files.bundle, function (err, output) {
                 t.ifError(err);
                 t.equal(output, '555\n');
-                fs.writeFile(files.main, 'console.log(333)');
+                fs.writeFile(files.main, 'console.log(333)', t.ifError);
             })
         }
         else if (lineNum === 2) {


### PR DESCRIPTION
Using async fs functions without callbacks is deprecated and will
throw in future versions. This adds a callback and checks that it
does not error.

Refs: https://github.com/nodejs/node/pull/18668