### PR TITLE
upgrade dependencies: security vulnerability in braces < 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
-    "anymatch": "^1.3.0",
+    "anymatch": "^2.0.0",
     "browserify": "^16.1.0",
-    "chokidar": "^1.0.0",
+    "chokidar": "^2.1.1",
     "defined": "^1.0.0",
     "outpipe": "^1.1.0",
     "through2": "^2.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "brfs": "^1.0.1",
+    "brfs": "^2.0.1",
     "mkdirp": "~0.5.1",
     "split": "^1.0.0",
     "tape": "^4.2.2",


### PR DESCRIPTION
Upgrade dependencies for watchify to mitigate security vulnerabilities detected by `npm audit`:

Upgrade https://github.com/micromatch/anymatch and https://github.com/paulmillr/chokidar to newest release versions, in order to fix a security vulnerability caused by https://github.com/micromatch/braces < 2.3.1: https://www.npmjs.com/advisories/786

Upgrade https://github.com/browserify/brfs to 2.0.1 to fix security vulnerability caused by https://github.com/browserify/static-eval: https://www.npmjs.com/advisories/758

