### PR TITLE
Fix hanging on error (Issue #368)

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,9 +96,11 @@ function watchify (b, opts) {
     });
     b.on('bundle', function (bundle) {
         updating = true;
-        bundle.on('error', onend);
-        bundle.on('end', onend);
-        function onend () { updating = false }
+        bundle.on('error', function (e) {
+            updating = false;
+            b.emit('error', e);
+        });
+        bundle.on('end', function () { updating = false; });
     });
 
     function watchFile (file, dep) {


### PR DESCRIPTION
https://github.com/browserify/watchify/issues/368

The error was swallowed, and the next pipe was never called, & the buffer was left open.