### PR TITLE
update chokidar and anymatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: node_js
 node_js:
   - "stable"
+  - "14"
+  - "12"
   - "10"
-  - "9"
   - "8"
-  - "6"
-  - "4"
-  - "iojs"
-  - "0.12"
-  - "0.10"
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "bin": "bin/cmd.js",
   "dependencies": {
-    "anymatch": "^2.0.0",
+    "anymatch": "^3.1.0",
     "browserify": "^16.1.0",
-    "chokidar": "^2.1.1",
+    "chokidar": "^3.4.0",
     "defined": "^1.0.0",
     "outpipe": "^1.1.0",
     "through2": "^2.0.0",


### PR DESCRIPTION
This PR is based on the PR #371 to update chokidar to latest version as well as anymatch to fix security warnings for dependent cache-base package.

test succesfully run with chokidar@3.4.3 and anymatch@3.1.1 on local NodeJS 12.x

Updating these two dependencies updates minimum NodeJS version required to 8.x.
But NodeJS 8.x is EOL since more than a year by now (Dec 2019).